### PR TITLE
Implement task lists

### DIFF
--- a/addons/markdownlabel/README.md
+++ b/addons/markdownlabel/README.md
@@ -43,7 +43,7 @@ My initial use case that lead me to do this was to directly include text from fi
 
 ## Usage
 
-Simply add a MarkdownLabel to the scene and write its `markdown_text` field in Markdown format.
+Simply add a MarkdownLabel to the scene and write its `markdown_text` field in Markdown format. Alternatively, you can use the ``display_file`` method to automatically import the contents of a Markdown file.
 
 In the RichTextLabel properties:
 - Do not touch neither the `bbcode_enabled` nor the `text` property, since they are internally used by MarkdownLabel to properly format its text. Both properties are hidden from the editor to prevent mistakenly editing them.

--- a/addons/markdownlabel/README.md
+++ b/addons/markdownlabel/README.md
@@ -186,7 +186,7 @@ Third element. The number at the beginning doesn't need to match the actual orde
 
 #### Task list items
 
-A task list item is an unordered list item which begins with ``[ ]`` or ``[x]``. These characters are, by default, replaced with a checkbox icon when converting the text (☐ and ☑, respectively). These checkbox characters depend on the used font and may not display properly, so they can be customized using the ``unchecked_item_character`` and ``checked_item_character`` properties, where you can even insert an image using BBCode or Markdown syntax.
+A task list item is an unordered list item which begins with ``[ ]`` or ``[x]`` followed by a space. These characters are, by default, replaced with a checkbox icon when converting the text (☐ and ☑, respectively). These checkbox characters depend on the used font and may not display properly, so they can be customized using the ``unchecked_item_character`` and ``checked_item_character`` properties, where you can even insert an image using BBCode or Markdown syntax.
 
 When clicking on a checkbox, it automatically checks/unchecks itself and emits the ``task_checkbox_clicked`` signal. This behavior can be disabled with the ``enable_checkbox_clicks`` property.
 

--- a/addons/markdownlabel/README.md
+++ b/addons/markdownlabel/README.md
@@ -15,6 +15,7 @@ A custom [Godot](https://godotengine.org/) node that extends [RichTextLabel](htt
   - [Lists](#lists)
   - [Tables](#tables)
   - [Escaping characters](#escaping-characters)
+  - [Advanced usage](#advanced-usage)
 - [Limitations](#limitations)
   - [Unsupported syntax elements](#unsupported-syntax-elements)
   - [Performance](#performance)
@@ -235,6 +236,12 @@ Keep in mind that, if you are writing text inside a script, you will have to "do
 - In-script: `\\*`, `\\\"`
 - In-editor: `\*`, `\"`
 - Result: `*`, `"`
+
+### Advanced usage
+
+MarkdownLabel can be customized to handle custom syntax if desired. There are two methods which are meant to support this use case: ``_preprocess_line()`` and ``_process_custom_syntax()``. These are called line by line and do nothing by default. ``_preprocess_line()`` is called before any syntax in the line is processed by the node, while ``_process_custom_syntax()`` is called after all syntax has been processed. These methods take a line as argument and return a processed line. This way, you can create a node that inherits from MarkdownLabel and override these methods in order to implement your custom syntax.
+
+For even more advanced customization, you can override other built-in methods, like ``_process_text_formatting_syntax()`` or ``_process_link_syntax()``. Check the source code for more information.
 
 ## Limitations
 

--- a/addons/markdownlabel/README.md
+++ b/addons/markdownlabel/README.md
@@ -13,6 +13,7 @@ A custom [Godot](https://godotengine.org/) node that extends [RichTextLabel](htt
   - [Links](#links)
   - [Images](#images)
   - [Lists](#lists)
+    - [Task list items (checkboxes)](#task-list-items)
   - [Tables](#tables)
   - [Escaping characters](#escaping-characters)
   - [Advanced usage](#advanced-usage)
@@ -182,6 +183,29 @@ Third element. The number at the beginning doesn't need to match the actual orde
 [ol]This is a nested list inside another nested list.[/ol]
 [/ul][/ol]
 ```
+
+#### Task list items
+
+A task list item is an unordered list item which begins with ``[ ]`` or ``[x]``. These characters are, by default, replaced with a checkbox icon when converting the text (☐ and ☑, respectively). These checkbox characters depend on the used font and may not display properly, so they can be customized using the ``unchecked_item_character`` and ``checked_item_character`` properties, where you can even insert an image using BBCode or Markdown syntax.
+
+When clicking on a checkbox, it automatically checks/unchecks itself and emits the ``task_checkbox_clicked`` signal. This behavior can be disabled with the ``enable_checkbox_clicks`` property.
+
+The arguments of the ``task_checkbox_clicked`` signal are:
+
+- The id of the checkbox (used internally)
+- The line number it is on (within the original Markdown text)
+- A boolean representing whether the checkbox is now checked (true) or unchecked (false)
+- A string containing the text after the checkbox (within the same line).
+
+Example (run the ``example.tscn`` scene to test it):
+
+- [ ] This is an unchecked item
+  - [x] This is a nested task
+- [x] This is a checked item
+  1. This is a nested regular list
+  2. Here goes another nested task list:
+    - [ ] Task 1
+    - [ ] Task 2
 
 ### Tables
 

--- a/addons/markdownlabel/example.gd
+++ b/addons/markdownlabel/example.gd
@@ -3,3 +3,7 @@ extends Control
 
 func _ready() -> void:
 	$MarkdownLabel.display_file("res://addons/markdownlabel/README.md")
+	$MarkdownLabel.task_checkbox_clicked.connect(
+		func(id: int, line: int, checked: bool, text: String) -> void:
+			print("%s task #%d on line %d: %s" % ["Checked" if checked else "Unchecked", id, line, text])
+	)

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -6,7 +6,7 @@ extends RichTextLabel
 ## A custom node that extends [RichTextLabel] to use Markdown instead of BBCode.
 ## [br][br]
 ## [b][u]Usage:[/u][/b]
-## Simply add a MarkdownLabel to the scene and write its [member markdown_text] field in Markdown format.
+## Simply add a MarkdownLabel to the scene and write its [member markdown_text] field in Markdown format. Alternatively, you can use the  [method display_file] method to automatically import the contents of a Markdown file.
 ## [br][br]
 ## On its [RichTextLabel] properties: [member RichTextLabel.bbcode_enabled] property must be enabled. Do not touch the [member RichTextLabel.text] property, since it's used by MarkdownLabel to properly format its text. You can use the rest of its properties as normal.
 ## [br][br]
@@ -56,7 +56,7 @@ var _header_anchor_paragraph := {}
 var _header_anchor_count := {}
 var _within_table := false
 var _table_row := -1
-var _line_break := true
+var _skip_line_break := false
 var _debug_mode := false
 #endregion
 
@@ -170,16 +170,16 @@ func _convert_markdown(source_text = "") -> String:
 	var current_code_block_char_count: int
 	_within_table = false
 	_table_row = -1
-	_line_break = true
+	_skip_line_break = false
 
 	for line in lines:
 		line = line.trim_suffix("\r")
 		_debug("Parsing line: '%s'" % line)
 		within_code_block = within_tilde_block or within_backtick_block
-		if iline > 0 and _line_break:
+		if iline > 0 and not _skip_line_break:
 			_converted_text += "\n"
 			_current_paragraph += 1
-			_line_break = true
+		_skip_line_break = false
 		iline+=1
 		if not within_tilde_block and _denotes_fenced_code_block(line,"`"):
 			if within_backtick_block:
@@ -573,7 +573,7 @@ func _process_table_syntax(line: String) -> String:
 		if _within_table:
 			_debug ("... end of table")
 			_within_table = false
-			return "\n[/table]\n"+line
+			return "[/table]\n"+line
 		else:
 			return line
 	_debug("... table row: "+line)
@@ -592,7 +592,7 @@ func _process_table_syntax(line: String) -> String:
 				is_delimiter = false
 				break
 		if is_delimiter:
-			_line_break = false
+			_skip_line_break = true
 			return ""
 	for cell in split_line:
 		processed_line += "[cell]%s[/cell]" % cell.strip_edges()

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -399,7 +399,7 @@ func _process_list_syntax(line: String, indent_spaces: Array, indent_types: Arra
 	return processed_line
 
 func _process_task_list_item(item: String) -> String:
-	if item.length() <= 2 or item[0] != "[" or item[2] != "]" or not item[1] in " x":
+	if item.length() <= 3 or item[0] != "[" or item[2] != "]" or item[3] != " " or not item[1] in " x":
 		return item
 	var processed_item := item.erase(0, 3)
 	var checkbox: String
@@ -761,5 +761,5 @@ func _on_checkbox_clicked(id: int, was_checked: bool) -> void:
 		return
 	lines[iline] = lines[iline].erase(i, old_string.length()).insert(i, new_string)
 	markdown_text = "\n".join(lines)
-	task_checkbox_clicked.emit(id, iline, !was_checked, lines[iline].substr(i + 3))
+	task_checkbox_clicked.emit(id, iline, !was_checked, lines[iline].substr(i + 4))
 #endregion

--- a/addons/markdownlabel/plugin.cfg
+++ b/addons/markdownlabel/plugin.cfg
@@ -3,5 +3,5 @@
 name="MarkdownLabel"
 description="A custom node that extends RichTextLabel to use Markdown instead of BBCode."
 author="Daenvil"
-version="1.1.0"
+version="1.2.0"
 script="plugin.gd"

--- a/tests/test_cases.json
+++ b/tests/test_cases.json
@@ -194,4 +194,9 @@
 		"output": "[table=2]\n[cell][b]foo[/b][/cell][cell][i]bar[/i][/cell]\n[cell][s]baz[/s][/cell][cell][code]baz[/code][/cell]\n[/table]",
 		"title": "Table without demiliter row and with in-line formatting"
 	},
+	{
+		"input": "- [ ] foo\n  - [x] foo\n- [x] bar\n  1. baz\n  2. baz\n    - [ ] task\n    - [ ] task",
+		"output": "[ul][url={\"checked\":false,\"id\":0,\"markdownlabel-checkbox\":true}]☐[/url] foo\n[ul][url={\"checked\":true,\"id\":1,\"markdownlabel-checkbox\":true}]☑[/url] foo\n[/ul]\n[url={\"checked\":true,\"id\":2,\"markdownlabel-checkbox\":true}]☑[/url] bar\n[ol]baz\nbaz\n[ul][url={\"checked\":false,\"id\":3,\"markdownlabel-checkbox\":true}]☐[/url] task\n[url={\"checked\":false,\"id\":4,\"markdownlabel-checkbox\":true}]☐[/url] task[/ul][/ol][/ul]",
+		"title": "Task list nesting"
+	}
 ]

--- a/tests/test_main.gd
+++ b/tests/test_main.gd
@@ -22,20 +22,25 @@ func main() -> void:
 	# Perform tests:
 	var failed_tests := []
 	var case_count := 0
-	for case in test_cases:
+	for case: Dictionary in test_cases:
 		if not specific_cases.is_empty() and not case.title in specific_cases:
 			continue
 		case_count += 1
-		var result = md_label._convert_markdown(case.input)
-		var success = result == case.output
+		var result := md_label._convert_markdown(case.input)
+		var success: bool = result == case.output
 		if not success:
-			failed_tests.append({"title":case.title,"input":case.input,"output":case.output,"result":result})
+			failed_tests.append({
+				"title": case.title,
+				"input": case.input,
+				"output": case.output,
+				"result": result
+			})
 	
 	# Display test results:
 	if failed_tests.size() > 0:
-		print_rich("[color=#ff6666]Tests: %d errors:[/color]"%failed_tests.size())
-		for case in failed_tests:
-			print_rich("[color=#ff6666]- %s[/color]"%case["title"])
+		print_rich("[color=#ff6666]Tests: %d errors:[/color]" % failed_tests.size())
+		for case: Dictionary in failed_tests:
+			print_rich("[color=#ff6666]- %s[/color]" % case.title)
 			print_rich("[color=#ff6666]  - Input:[/color]")
 			print(case["input"])
 			print_rich("[color=#ff6666]  - Expected result:[/color]")
@@ -46,7 +51,7 @@ func main() -> void:
 		if specific_cases.is_empty():
 			print_rich("[color=#66ff66]All tests: OK[/color]")
 		elif case_count>0:
-			print_rich("[color=#66ff66]Specific tests: OK (%d/%d tests)[/color]" % [case_count,specific_cases.size()])
+			print_rich("[color=#66ff66]Specific tests: OK (%d/%d tests)[/color]" % [case_count, specific_cases.size()])
 	if case_count < specific_cases.size():
 		print_rich("[color=#ff6666]WARNING: not all specific cases were found.[/color]")
 	md_label.queue_free()


### PR DESCRIPTION
- Added support for task lists (closes #4):
  - Starting an unordered list item with ``[ ]`` or ``[x]`` will create a checkbox.
  - The checkboxes are clickable by default and emit a signal when clicked.
  - There's an option to disable cliking on checkboxes.
  - There's an option to customize the checkbox.
  - See the README file in the repo for more info.
- Added support for custom syntax (closes #7):
  - Refactored the processing of all syntax elements into individual methods so they can be overridden if desired (``_process_text_formatting_syntax()``, ``_process_link_syntax()``, etc.).
  - Added two empty methods: ``_preprocess_line()`` and ``_process_custom_syntax()`` which can be overridden to insert custom syntax.
- Fixed bug where a table could break all the following text.