### PR TITLE
Adding Translation support

### DIFF
--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -154,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) if can_auto_translate() else markdown_text)
+	text = _convert_markdown( TranslationServer.translate(markdown_text) as StringName if can_auto_translate() else markdown_text)
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -154,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) )
+	text = _convert_markdown( TranslationServer.translate(markdown_text) if can_auto_translate() else markdown_text)
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -140,6 +140,10 @@ func _validate_property(property: Dictionary) -> void:
 	if property.name in ["bbcode_enabled", "text"]:
 		property.usage = PROPERTY_USAGE_NO_EDITOR
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_TRANSLATION_CHANGED:
+		_update()
+
 #endregion
 
 #region Public methods:
@@ -150,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown(markdown_text)
+	text = _convert_markdown( TranslationServer.translate(markdown_text) )
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:


### PR DESCRIPTION
This PR has two changes:

## Calling TranslationServer
In `_update()`, I call the TranslationServer to check if a translatioon is available for the provided markdown text.

I have briefly considered adding support for plural translations, but this goes over my head right now and would need a more deliberate consideration to prevent from this messing with the markdown syntax. I also think it is likely not useful for `MarkdownLabel` to begin with as it would need to add support for in-text variables to begin with.

Writing this PR I just realized I should check for auto translate, adding that right now.

## Updating on `NOTIFICATION_TRANSLATION_CHANGED`

This just makes sure that the Label is automatically updated whenever the configured language changes.