### PR TITLE
Draft: Implement override for `text` property

### DIFF
--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -34,7 +34,7 @@ signal task_checkbox_clicked(id: int, line: int, checked: bool, task_string: Str
 ## Deprecated: Use [text] instead.
 var markdown_text: String :
 	set = _set_text,
-	get = _get_markdown_tex
+	get = _get_markdown_text
 
 ## If enabled, links will be automatically handled by this node, without needing to manually connect them. Valid header anchors will make the label scroll to that header's position. Valid URLs and e-mails will be opened according to the user's default settings.
 @export var automatic_links := true

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -154,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) if can_auto_translate() else markdown_text)
+	text = _convert_markdown( TranslationServer.translate(markdown_text) as StringName if can_auto_translate() else markdown_text)
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -144,6 +144,20 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_TRANSLATION_CHANGED:
 		_update()
 
+func _set(property: StringName, value: Variant) -> bool:
+	if property == "text":
+		markdown_text = value
+		return true
+	if property == "markdown_text":
+		text = value
+		return true
+	return false
+
+func _get(property: StringName) -> Variant:
+	if property == "text":
+		return markdown_text
+	return null
+
 #endregion
 
 #region Public methods:
@@ -154,7 +168,8 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) as StringName if can_auto_translate() else markdown_text)
+	super.clear()
+	super.parse_bbcode(_convert_markdown( TranslationServer.translate(markdown_text) as StringName if can_auto_translate() else markdown_text))
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -154,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) )
+	text = _convert_markdown( TranslationServer.translate(markdown_text) if can_auto_translate() else markdown_text)
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -140,6 +140,10 @@ func _validate_property(property: Dictionary) -> void:
 	if property.name in ["bbcode_enabled", "text"]:
 		property.usage = PROPERTY_USAGE_NO_EDITOR
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_TRANSLATION_CHANGED:
+		_update()
+
 #endregion
 
 #region Public methods:
@@ -150,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown(markdown_text)
+	text = _convert_markdown( TranslationServer.translate(markdown_text) )
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -148,9 +148,6 @@ func _set(property: StringName, value: Variant) -> bool:
 	if property == "text":
 		markdown_text = value
 		return true
-	if property == "markdown_text":
-		text = value
-		return true
 	return false
 
 func _get(property: StringName) -> Variant:


### PR DESCRIPTION
This implements #2 

To prevent a merge conflict in _update(), it also includes changes made in #18

I am using the _set() and _get() methods to change the behavior of the text `variable` in the `super` class.

Please consider this to be a draft, because I have not tested this a lot.

## Additional Notes
~~I have tried to remove the `markdown_text` property as this change makes it somewhat redundant. However in testing it did not really work and things got tangled up. I think it had something to do with the inspector calling get text, but honestly I would need to look further into it.~~

Update: I actually managed to remove [markdown_text]. But I honestly it is kind of redundant because I still need the [_original_text]

~~It may also just not be worth the effort honestly.~~
You can revert the last two commits if you don't like it.

~~However if you want to remove `markdown_text`, you should add it as a virtual property by overriding get_property_list and adding it to the set function so users that update this AddOn won't lose all their markdown texts. (see the review)~~
 ~> I have made this would not be a breaking change.