### PR TITLE
Override text property

### DIFF
--- a/addons/markdownlabel/README.md
+++ b/addons/markdownlabel/README.md
@@ -56,10 +56,11 @@ You might need to reload the project.
 
 ## Usage
 
-Simply add a MarkdownLabel to the scene and write its `markdown_text` field in Markdown format. Alternatively, you can use the ``display_file`` method to automatically import the contents of a Markdown file.
+Simply add a MarkdownLabel to the scene and write its `markdown_text` field in Markdown format. Alternatively, you can use the `display_file` method to automatically import the contents of a Markdown file.
 
 In the RichTextLabel properties:
-- Do not touch neither the `bbcode_enabled` nor the `text` property, since they are internally used by MarkdownLabel to properly format its text. Both properties are hidden from the editor to prevent mistakenly editing them.
+- Do not touch the `bbcode_enabled` property, since it's automatically set to `true` by MarkdownLabel to properly format its text. It's hidden from the editor to prevent misusage.
+- Editing the `text` property has the same effect as editing `markdown_text`. It's hidden from the editor to prevent misusage.
 - You can use the rest of its properties as normal.
 
 You can still use BBCode tags that don't have a Markdown equivalent, such as `[color=green]underlined text[/color]`, allowing you to have the full functionality of RichTextLabel with the simplicity and readibility of Markdown.

--- a/addons/markdownlabel/example.gd
+++ b/addons/markdownlabel/example.gd
@@ -2,8 +2,8 @@ extends Control
 
 
 func _ready() -> void:
-	$MarkdownLabel.display_file("res://addons/markdownlabel/README.md")
-	$MarkdownLabel.task_checkbox_clicked.connect(
+	%MarkdownLabelFile.display_file("res://addons/markdownlabel/README.md")
+	%MarkdownLabelFile.task_checkbox_clicked.connect(
 		func(id: int, line: int, checked: bool, text: String) -> void:
 			print("%s task #%d on line %d: %s" % ["Checked" if checked else "Unchecked", id, line, text])
 	)

--- a/addons/markdownlabel/example.tscn
+++ b/addons/markdownlabel/example.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://bka0d50qmnb8y"]
+[gd_scene load_steps=21 format=3 uid="uid://bka0d50qmnb8y"]
 
 [ext_resource type="Script" uid="uid://bm7huuxd3k4yu" path="res://addons/markdownlabel/example.gd" id="1_7b8dd"]
 [ext_resource type="Script" uid="uid://dbap0gqox0ty1" path="res://addons/markdownlabel/markdownlabel.gd" id="2_opcio"]
@@ -9,65 +9,53 @@
 [ext_resource type="Script" uid="uid://dfr1w7u3jgni3" path="res://addons/markdownlabel/header_formats/h5_format.gd" id="7_42de6"]
 [ext_resource type="Script" uid="uid://bsi6dexoofpe6" path="res://addons/markdownlabel/header_formats/h6_format.gd" id="8_y8fds"]
 
+[sub_resource type="Resource" id="Resource_s4fot"]
+resource_local_to_scene = true
+script = ExtResource("3_kbjha")
+
+[sub_resource type="Resource" id="Resource_qroun"]
+resource_local_to_scene = true
+script = ExtResource("4_tqhuu")
+
+[sub_resource type="Resource" id="Resource_dgj8w"]
+resource_local_to_scene = true
+script = ExtResource("5_us0p7")
+
+[sub_resource type="Resource" id="Resource_cuayb"]
+resource_local_to_scene = true
+script = ExtResource("6_8ublj")
+
+[sub_resource type="Resource" id="Resource_vxc6j"]
+resource_local_to_scene = true
+script = ExtResource("7_42de6")
+
+[sub_resource type="Resource" id="Resource_fxeak"]
+resource_local_to_scene = true
+script = ExtResource("8_y8fds")
+
 [sub_resource type="Resource" id="Resource_r7ev3"]
 resource_local_to_scene = true
 script = ExtResource("3_kbjha")
-font_size = 2.285
-is_bold = false
-is_italic = false
-is_underlined = false
-override_font_color = false
-font_color = Color(1, 1, 1, 1)
 
 [sub_resource type="Resource" id="Resource_qh6ic"]
 resource_local_to_scene = true
 script = ExtResource("4_tqhuu")
-font_size = 1.714
-is_bold = false
-is_italic = false
-is_underlined = false
-override_font_color = false
-font_color = Color(1, 1, 1, 1)
 
 [sub_resource type="Resource" id="Resource_qx73p"]
 resource_local_to_scene = true
 script = ExtResource("5_us0p7")
-font_size = 1.428
-is_bold = false
-is_italic = false
-is_underlined = false
-override_font_color = false
-font_color = Color(1, 1, 1, 1)
 
 [sub_resource type="Resource" id="Resource_yx0wh"]
 resource_local_to_scene = true
 script = ExtResource("6_8ublj")
-font_size = 1.142
-is_bold = false
-is_italic = false
-is_underlined = false
-override_font_color = false
-font_color = Color(1, 1, 1, 1)
 
 [sub_resource type="Resource" id="Resource_1ovcl"]
 resource_local_to_scene = true
 script = ExtResource("7_42de6")
-font_size = 1.0
-is_bold = false
-is_italic = false
-is_underlined = false
-override_font_color = false
-font_color = Color(1, 1, 1, 1)
 
 [sub_resource type="Resource" id="Resource_fj0e0"]
 resource_local_to_scene = true
 script = ExtResource("8_y8fds")
-font_size = 0.857
-is_bold = false
-is_italic = false
-is_underlined = false
-override_font_color = false
-font_color = Color(1, 1, 1, 1)
 
 [node name="Example" type="Control"]
 layout_mode = 3
@@ -78,13 +66,33 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_7b8dd")
 
-[node name="MarkdownLabel" type="RichTextLabel" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="MarkdownLabel" type="RichTextLabel" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+bbcode_enabled = true
+text = "This is a **test** of a simple [color=green]*MarkdownLabel*[/color] [u]set in the editor[/u]. Below is a MarkdownLabel displaying a text read from a file."
+fit_content = true
+script = ExtResource("2_opcio")
+h1 = SubResource("Resource_s4fot")
+h2 = SubResource("Resource_qroun")
+h3 = SubResource("Resource_dgj8w")
+h4 = SubResource("Resource_cuayb")
+h5 = SubResource("Resource_vxc6j")
+h6 = SubResource("Resource_fxeak")
+metadata/_custom_type_script = "uid://dbap0gqox0ty1"
+
+[node name="MarkdownLabelFile" type="RichTextLabel" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
 bbcode_enabled = true
 script = ExtResource("2_opcio")
 h1 = SubResource("Resource_r7ev3")

--- a/addons/markdownlabel/example.tscn
+++ b/addons/markdownlabel/example.tscn
@@ -78,9 +78,9 @@ grow_vertical = 2
 unique_name_in_owner = true
 layout_mode = 2
 bbcode_enabled = true
-text = "This is a **test** of a simple [color=green]*MarkdownLabel*[/color] [u]set in the editor[/u]. Below is a MarkdownLabel displaying a text read from a file."
 fit_content = true
 script = ExtResource("2_opcio")
+markdown_text = "This is a **test** of a simple [color=green]*MarkdownLabel*[/color] [u]set in the editor[/u]. Below is a MarkdownLabel displaying a text read from a file."
 h1 = SubResource("Resource_s4fot")
 h2 = SubResource("Resource_qroun")
 h3 = SubResource("Resource_dgj8w")

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -34,7 +34,7 @@ signal task_checkbox_clicked(id: int, line: int, checked: bool, task_string: Str
 ## Deprecated: Use [text] instead.
 var markdown_text: String :
 	set = _set_text,
-	get = _get_markdown_tex
+	get = _get_markdown_text
 
 ## If enabled, links will be automatically handled by this node, without needing to manually connect them. Valid header anchors will make the label scroll to that header's position. Valid URLs and e-mails will be opened according to the user's default settings.
 @export var automatic_links := true

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -154,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) if can_auto_translate() else markdown_text)
+	text = _convert_markdown( TranslationServer.translate(markdown_text) as StringName if can_auto_translate() else markdown_text)
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -22,7 +22,7 @@ const _ESCAPEABLE_CHARACTERS_REGEX := "[\\\\\\*\\_\\~`\\[\\]\\(\\)\\\"\\<\\>#\\-
 const _CHECKBOX_KEY := "markdownlabel-checkbox"
 
 #region Public:
-## Emitted when the node does not handle a click on a link. Can be used to execute custom functions when a link is clicked. [code]meta[/code] is the link metadata (in a regular link, it would be the URL).
+## Emitted when the node does not handle a click on a link. Can be used to execute custom functions when a link is clicked. [param meta] is the link metadata (in a regular link, it would be the URL).
 signal unhandled_link_clicked(meta: Variant)
 ## Emitted when a task list checkbox is clicked. Arguments are:
 ## the id of the checkbox (used internally),
@@ -31,12 +31,13 @@ signal unhandled_link_clicked(meta: Variant)
 ## and a string containing the text after the checkbox (within the same line).
 signal task_checkbox_clicked(id: int, line: int, checked: bool, task_string: String)
 
-## Deprecated: Use [text] instead.
-var markdown_text: String : set = _set_markdown_text
+## The text to be displayed in Markdown format.[br][br]
+## [i]Note: the [member RichTextLabel.text] property is overridden so modifying it through code has the same effect as modifying [member markdown_text].[/i]
+@export_multiline var markdown_text: String : set = _set_markdown_text
 
 ## If enabled, links will be automatically handled by this node, without needing to manually connect them. Valid header anchors will make the label scroll to that header's position. Valid URLs and e-mails will be opened according to the user's default settings.
 @export var automatic_links := true
-## If enabled, unrecognized links will be opened as HTTPS URLs (e.g. "example.com" will be opened as "https://example.com"). If disabled, unrecognized links will be left unhandled (emitting the [code]unhandled_link_clicked[/code] signal). Ignored if [code]automatic_links[/code] is disabled.
+## If enabled, unrecognized links will be opened as HTTPS URLs (e.g. "example.com" will be opened as "https://example.com"). If disabled, unrecognized links will be left unhandled (emitting the [signal unhandled_link_clicked] signal). Ignored if [member automatic_links] is disabled.
 @export var assume_https_links := true
 
 @export_group("Header formats")
@@ -136,9 +137,10 @@ func _on_meta_clicked(meta: Variant) -> void:
 		unhandled_link_clicked.emit(meta)
 
 func _validate_property(property: Dictionary) -> void:
-	# Hide these properties in the editor:
-	if property.name  == "bbcode_enabled":
+	if property.name == "bbcode_enabled":
 		property.usage = PROPERTY_USAGE_NO_EDITOR
+	elif property.name == "text":
+		property.usage = PROPERTY_USAGE_NONE # Don't store in scene file (markdown_text is already stored) nor show in editor
 
 func _set(property: StringName, value: Variant) -> bool:
 	if property == "text":

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -144,6 +144,20 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_TRANSLATION_CHANGED:
 		_update()
 
+func _set(property: StringName, value: Variant) -> bool:
+	if property == "text":
+		markdown_text = value
+		return true
+	if property == "markdown_text":
+		text = value
+		return true
+	return false
+
+func _get(property: StringName) -> Variant:
+	if property == "text":
+		return markdown_text
+	return null
+
 #endregion
 
 #region Public methods:
@@ -154,7 +168,8 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) as StringName if can_auto_translate() else markdown_text)
+	super.clear()
+	super.parse_bbcode(_convert_markdown( TranslationServer.translate(markdown_text) as StringName if can_auto_translate() else markdown_text))
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -154,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown( TranslationServer.translate(markdown_text) )
+	text = _convert_markdown( TranslationServer.translate(markdown_text) if can_auto_translate() else markdown_text)
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -140,6 +140,10 @@ func _validate_property(property: Dictionary) -> void:
 	if property.name in ["bbcode_enabled", "text"]:
 		property.usage = PROPERTY_USAGE_NO_EDITOR
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_TRANSLATION_CHANGED:
+		_update()
+
 #endregion
 
 #region Public methods:
@@ -150,7 +154,7 @@ func display_file(file_path: String) -> void:
 
 #region Private methods:
 func _update() -> void:
-	text = _convert_markdown(markdown_text)
+	text = _convert_markdown( TranslationServer.translate(markdown_text) )
 	queue_redraw()
 
 func _set_markdown_text(new_text: String) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -143,10 +143,6 @@ func _validate_property(property: Dictionary) -> void:
 	if property.name  == "bbcode_enabled":
 		property.usage = PROPERTY_USAGE_NO_EDITOR
 
-func _notification(what: int) -> void:
-	if what == NOTIFICATION_TRANSLATION_CHANGED:
-		_update()
-
 func _set(property: StringName, value: Variant) -> bool:
 	if property == "text":
 		_set_text(value)
@@ -181,7 +177,7 @@ func _get_markdown_text() -> String:
 
 func _update() -> void:
 	super.clear()
-	super.parse_bbcode(_convert_markdown( TranslationServer.translate(_original_text) as StringName if can_auto_translate() else _original_text))
+	super.parse_bbcode(_convert_markdown(_original_text))
 	queue_redraw()
 
 func _set_h1_format(new_format: H1Format) -> void:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -148,9 +148,6 @@ func _set(property: StringName, value: Variant) -> bool:
 	if property == "text":
 		markdown_text = value
 		return true
-	if property == "markdown_text":
-		text = value
-		return true
 	return false
 
 func _get(property: StringName) -> Variant:

--- a/addons/markdownlabel/markdownlabel.gd
+++ b/addons/markdownlabel/markdownlabel.gd
@@ -32,9 +32,7 @@ signal unhandled_link_clicked(meta: Variant)
 signal task_checkbox_clicked(id: int, line: int, checked: bool, task_string: String)
 
 ## Deprecated: Use [text] instead.
-var markdown_text: String :
-	set = _set_text,
-	get = _get_markdown_text
+var markdown_text: String : set = _set_markdown_text
 
 ## If enabled, links will be automatically handled by this node, without needing to manually connect them. Valid header anchors will make the label scroll to that header's position. Valid URLs and e-mails will be opened according to the user's default settings.
 @export var automatic_links := true
@@ -74,7 +72,6 @@ var markdown_text: String :
 #endregion
 
 #region Private:
-var _original_text: String = "": set = _set_original_text
 var _converted_text: String
 var _indent_level: int
 var _escaped_characters_map := {}
@@ -151,7 +148,7 @@ func _set(property: StringName, value: Variant) -> bool:
 
 func _get(property: StringName) -> Variant:
 	if property == "text":
-		return _original_text
+		return markdown_text
 	return null
 
 #endregion
@@ -159,25 +156,21 @@ func _get(property: StringName) -> Variant:
 #region Public methods:
 ## Reads the specified file and displays it as markdown.
 func display_file(file_path: String) -> void:
-	_original_text = FileAccess.get_file_as_string(file_path)
+	markdown_text = FileAccess.get_file_as_string(file_path)
 #endregion
 
 #region Private methods:
 func _set_text(new_text: String) -> void:
-	_original_text = new_text
+	markdown_text = new_text
 	_update()
 
-func _set_original_text(new_text: String) -> void:
-	_original_text = new_text
+func _set_markdown_text(new_text: String) -> void:
+	markdown_text = new_text
 	_update()
-
-# This just makes sure scripts that use the deprecated [markdown_text] variable won't break.
-func _get_markdown_text() -> String:
-	return text
 
 func _update() -> void:
 	super.clear()
-	super.parse_bbcode(_convert_markdown(_original_text))
+	super.parse_bbcode(_convert_markdown(markdown_text))
 	queue_redraw()
 
 func _set_h1_format(new_format: H1Format) -> void:
@@ -769,7 +762,7 @@ func _get_header_reference(header_string: String) -> String:
 
 func _on_checkbox_clicked(id: int, was_checked: bool) -> void:
 	var iline: int = _checkbox_record[id]
-	var lines := _original_text.split("\n")
+	var lines := markdown_text.split("\n")
 	var old_string := "[x]" if was_checked else "[ ]"
 	var new_string := "[ ]" if was_checked else "[x]"
 	var i := lines[iline].find(old_string)


### PR DESCRIPTION
Based on #19 with additional changes:

- Reuse the existing ``markdown_text`` property instead of creating a new hidden one
- The ``markdown_text`` property is still exposed in the editor, this way it will be more clear that it's for Markdown format (otherwise, the ``text`` property's tooltip suggest using BBCode)
- Both ``markdown_text`` and ``text`` have the same effect when used through code (which is the main thing that I wanted)
- Improved documentation comments

TODO:

- [x] Do more tests
- [x] Update README.md to reflect the use of ``text``